### PR TITLE
Remove some hidden text

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -117,7 +117,7 @@
 		</Cta>
 
 		<form class="w-full flex flex-col items-center -mt-6" on:submit|preventDefault={onSubmit}>
-			<h1 class="my-2 text-white text-xl text-center">My custom search widget</h1>
+			<h1 class="my-2 text-white text-xl text-center">&nbsp;</h1>
 			<div class="text-center mb-8">
 				<span class="font-bold">Example questions:</span>
 				<ButtonGroup>


### PR DESCRIPTION
The home page has a heading that reads "My custom search widget".  The heading is white text on a white background so it's hidden from users.

This change keeps the `<h1>` tag but changes the text to a simple `$nbsp;`.  It might be safe to remove the line completely but I do not have a way to run the site locally at the moment.